### PR TITLE
fix: upgrading portainer to docker-compose version 3

### DIFF
--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -1,10 +1,12 @@
-portainer:
-    image: portainer/portainer
-    container_name: portainer
-    ports:
-        - 9001:9000
-    restart: always
-    volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-        - ./portainer_data:/data
+version: '3'
+services:
+    portainer:
+        image: portainer/portainer
+        container_name: portainer
+        ports:
+            - 9001:9000
+        restart: always
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+            - ./portainer_data:/data
 


### PR DESCRIPTION
portainer docker-compose.yml does not work with docker-compose v2+, so, I'm updating to the  newer format